### PR TITLE
fix: windows installer and venv path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Plug 'yaegassy/coc-curlylint', {'do': 'yarn install --frozen-lockfile'}
 ## Detect: curlylint
 
 1. `curlylint.commandPath` setting
-1. PATH environment (e.g. system global PATH or venv/bin, etc ...)
-1. builtin: extension-only "venv/bin" (Installation commands are also provided)
+1. PATH environment (e.g. system global PATH or venv, etc ...)
+1. builtin: extension-only "venv" (Installation commands are also provided)
 
 ## Bult-in install
 
@@ -55,6 +55,7 @@ Alternatively, you can set any `pyproject.toml` file in the `curlylint.configPat
 
 - `curlylint.enable`: Enable coc-curlylint extension, default: `true`
 - `curlylint.commandPath`: The path to the curlylint command (Absolute path), default: `""`
+- `curlylint.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 - `curlylint.configPath`: Read configuration from the provided file (Absolute path), default: `""`
 - `curlylint.lintOnOpen`: Lint file on opening, default: `true`
 - `curlylint.lintOnChange`: Lint file on change, default: `true`

--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
           "default": "",
           "description": "The path to the curlylint command (Absolute path)"
         },
+        "curlylint.builtin.pythonPath": {
+          "type": "string",
+          "default": "",
+          "description": "Python 3.x path (Absolute path) to be used for built-in install"
+        },
         "curlylint.configPath": {
           "type": "string",
           "default": "",

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,22 +10,28 @@ import { CURLYLINT_VERSION } from './constant';
 
 const exec = util.promisify(child_process.exec);
 
-export async function curlylintInstall(context: ExtensionContext): Promise<void> {
+export async function curlylintInstall(pythonCommand: string, context: ExtensionContext): Promise<void> {
   const pathVenv = path.join(context.storagePath, 'curlylint', 'venv');
-  const pathPip = path.join(pathVenv, 'bin', 'pip');
+
+  let pathVenvPython = path.join(context.storagePath, 'curlylint', 'venv', 'bin', 'python');
+  if (process.platform === 'win32') {
+    pathVenvPython = path.join(context.storagePath, 'curlylint', 'venv', 'Scripts', 'python');
+  }
 
   const statusItem = window.createStatusBarItem(0, { progress: true });
   statusItem.text = `Install curlylint...`;
   statusItem.show();
 
-  const installCmd = `python3 -m venv ${pathVenv} && ` + `${pathPip} install -U pip curlylint==${CURLYLINT_VERSION}`;
+  const installCmd =
+    `${pythonCommand} -m venv ${pathVenv} && ` +
+    `${pathVenvPython} -m pip install -U pip curlylint==${CURLYLINT_VERSION}`;
 
   rimraf.sync(pathVenv);
   try {
-    window.showWarningMessage(`Install curlylint...`);
+    window.showMessage(`Install curlylint...`);
     await exec(installCmd);
     statusItem.hide();
-    window.showWarningMessage(`curlylint: installed!`);
+    window.showMessage(`curlylint: installed!`);
   } catch (error) {
     statusItem.hide();
     window.showErrorMessage(`curlylint: install failed. | ${error}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,11 +295,6 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"


### PR DESCRIPTION
- Fix path of venv on windows (Change to Scripts instead of bin.)
- Change the installation procedure to `python -m pip` instead of using pip in venv directly.
- Added python3 and python command detection (since python3 commands may not be present on Windows and other special environments).