### PR TITLE
fix: Use system global python command in the built-in installer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   const outputChannel = window.createOutputChannel('curlylint');
 
-  const pythonCommand = getPythonPath(extensionConfig);
+  const isRealpath = true;
+  const pythonCommand = getPythonPath(extensionConfig, isRealpath);
 
   subscriptions.push(
     commands.registerCommand('curlylint.install', async () => {
@@ -148,23 +149,27 @@ function whichCmd(cmd: string): string {
   }
 }
 
-function getPythonPath(config: WorkspaceConfiguration): string {
+function getPythonPath(config: WorkspaceConfiguration, isRealpath?: boolean): string {
   let pythonPath = config.get<string>('builtin.pythonPath', '');
   if (pythonPath) {
     return pythonPath;
   }
 
   try {
-    which.sync('python3');
-    pythonPath = 'python3';
+    pythonPath = which.sync('python3');
+    if (isRealpath) {
+      pythonPath = fs.realpathSync(pythonPath);
+    }
     return pythonPath;
   } catch (e) {
     // noop
   }
 
   try {
-    which.sync('python');
-    pythonPath = 'python';
+    pythonPath = which.sync('python');
+    if (isRealpath) {
+      pythonPath = fs.realpathSync(pythonPath);
+    }
     return pythonPath;
   } catch (e) {
     // noop


### PR DESCRIPTION
There is a problem that if the built-in installer is run while the project's virtual environment is activated, it will use the python commands of that project.

If the python3/python command detected is a symbolic link, resolve the link and change it to use the system global absolute path.